### PR TITLE
Improve tome path UX in faction creator

### DIFF
--- a/Data/Faction.js
+++ b/Data/Faction.js
@@ -51,6 +51,9 @@ var listOfPantheonTraits = [
 
 var currentTomeList = [];
 var currentSignatureSkills = [];
+// Tracks which tome index was clicked to open the add-tome popup, so the new tome
+// is inserted right after it instead of appended to the end. -1 means append (used during load).
+var tomeInsertionIndex = -1;
 
 function AddExtra(type, add) {
     if (type === "order") {
@@ -301,8 +304,8 @@ function selectOrigin(origin, type) {
         case "Tome":
             currentTome = origin;
             currentTomeList[0] = origin;
-            // update tome path
-            ClearTomePath();
+            // update tome path without clearing — invalid tomes will be flagged by GetInvalidTomeIndices
+            // ClearTomePath();
             selectTomePath(undefined, false);
 
             break;
@@ -445,6 +448,7 @@ function selectOrigin(origin, type) {
             break;
         case "SubType":
             currentSubType = origin;
+            selectTomePath(undefined, false);
             break;
         case "Ascension":
             currentAscension = origin;
@@ -461,13 +465,16 @@ function selectOrigin(origin, type) {
             break;
         case "SubCulture":
             currentSubCulture = origin;
+            selectTomePath(undefined, false);
             break;
 
         case "SubSociety1":
             currentSubSociety1 = origin;
+            selectTomePath(undefined, false);
             break;
         case "SubSociety2":
             currentSubSociety2 = origin;
+            selectTomePath(undefined, false);
             break;
     }
 
@@ -589,13 +596,11 @@ function SetTomePathOptions(evt) {
     var originWrapper = document.getElementById("originWrapperOptions");
     originWrapper.setAttribute("style", "grid-template-columns: repeat(7, 2fr);");
     originWrapper.innerHTML = "";
-    var list = [];
 
-    // assign current selection
+    // Get tomes valid at the insertion point, excluding any already in the full path.
+    var fullTomeList = currentTomeList;
+    var list = GetNextSetOfTomes(tomeInsertionIndex + 1).filter(t => !isInArray(fullTomeList, t));
 
-    list = GetNextSetOfTomes();
-
-    // console.log("Clicked");
     // List of origin options
 
     // Create origin buttons dynamically from the list
@@ -634,11 +639,28 @@ function selectTomePath(origin, fromLoad) {
 
     if (origin != undefined) {
         currentTomeList.push(origin);
+        // If a tome was clicked to open the popup, insert after it instead
+        if (tomeInsertionIndex >= 0) {
+            currentTomeList.pop();
+            currentTomeList.splice(tomeInsertionIndex + 1, 0, origin);
+        }
+        tomeInsertionIndex = -1;
     }
 
+    var invalidIndices = GetInvalidTomeIndices();
+
     for (var i = 0; i < currentTomeList.length; i++) {
-        SetTomePathInfoSmall(originButton, currentTomeList[i]);
+        SetTomePathInfoSmall(originButton, currentTomeList[i], i, invalidIndices.has(i));
     }
+    
+    var addSlot = document.createElement("div");
+    addSlot.className = "tome-add-slot";
+    addSlot.innerHTML = "+";
+    addSlot.addEventListener("click", function(event) {
+        tomeInsertionIndex = currentTomeList.length - 1;
+        SetTomePathOptions(event);
+    });
+    originButton.appendChild(addSlot);
 
     RecalculateStats(fromLoad);
     // swap current known origin
@@ -695,7 +717,7 @@ function SetSkillPathInfoSmall(buttonHolder, origin) {
 
     addTooltipListeners(image, spa);
 }
-function SetTomePathInfoSmall(buttonHolder, origin) {
+function SetTomePathInfoSmall(buttonHolder, origin, index, isInvalid) {
     const image = document.createElement("img");
     image.setAttribute("width", "60");
     image.setAttribute("height", "60");
@@ -731,6 +753,24 @@ function SetTomePathInfoSmall(buttonHolder, origin) {
         newDivButton.appendChild(DLCTAG);
     }
 
+    if (index > 0) {
+        let removeBtn = document.createElement("div");
+        removeBtn.innerHTML = "×";
+        removeBtn.className = "tome-remove-btn";
+        removeBtn.addEventListener("click", function(e) {
+            e.stopPropagation();
+            RemoveTomeAtIndex(index);
+        });
+        newDivButton.appendChild(removeBtn);
+    }
+
+    if (isInvalid) {
+        let warningIcon = document.createElement("div");
+        warningIcon.innerHTML = "!";
+        warningIcon.className = "tome-warning-icon";
+        newDivButton.appendChild(warningIcon);
+    }
+
     buttonHolder.append(newDivButton);
 
     // create mouseover
@@ -742,9 +782,41 @@ function SetTomePathInfoSmall(buttonHolder, origin) {
 
     SetTomePreview(spa, origin);
 
-    newDivButton.className = "tome-button-small";
+    // If the tome is invalid, append a warning to the tooltip describing the reason.
+    if (isInvalid && currentTomeList.indexOf(origin) !== currentTomeList.lastIndexOf(origin)) {
+        spa.innerHTML += '<p style="color:#e05252;margin-top:8px;font-weight:bold;">Already in the tome path</p>';
+    } else if (isInvalid && origin.tier >= 2) {
+        var req = tomeRequirements[origin.tier];
+        var partialList = currentTomeList.slice(0, index);
+        var partialAffinity = GetAffinityTotalFromList(
+            GetCurrentChoiceList(), partialList,
+            currentSubType, currentSubCulture, currentSubSociety1, currentSubSociety2
+        );
+        var tomeCountOk = partialList.length >= req.minTomes;
+        var affinityOk = req.minAffinity === 0 ||
+            GetAffinityMatches(partialAffinity, origin.affinities, req.minAffinity - 1);
 
-    newDivButton.addEventListener("click", (event) => SetTomePathOptions(event));
+        var warnHtml = '<p style="color:#e05252;margin-top:8px;font-weight:bold;">Requirements not met!</p>';
+        if (!tomeCountOk) {
+            warnHtml += '<p style="color:#e05252;">Needs ' + req.minTomes + ' tomes before this one</p>';
+        }
+        if (!affinityOk && "affinities" in origin) {
+            var affinityIcons = origin.affinities.split(", ").map(function(p) {
+                var match = p.match(/<\w+><\/\w+>/);
+                return match ? match[0] : "";
+            }).filter(function(p) { return p !== ""; });
+            warnHtml += '<p style="color:#e05252;">Needs ' + req.minAffinity + '+ ' + affinityIcons.join(" ") + '</p>';
+        }
+        spa.innerHTML += warnHtml;
+    }
+
+    newDivButton.className = "tome-button-small";
+    if (isInvalid) newDivButton.classList.add("tome-invalid");
+
+    newDivButton.addEventListener("click", (event) => {
+        tomeInsertionIndex = index;
+        SetTomePathOptions(event);
+    });
 
     // newDivButton.append(spa);
 
@@ -764,18 +836,11 @@ function RemoveLastSkill() {
     toggleOriginButtons();
 }
 
-function RemoveLastTomePath() {
-    if (currentTomeList.length > 1) {
-        currentTomeList.pop();
-    }
-
-    selectTomePath();
-
-    RecalculateStats(false);
-    // swap current known origin
-    // draw all tomes
-
-    toggleOriginButtons();
+// Removes a path tome by index and re-renders the tome path. Index 0 (starting tome) is protected.
+function RemoveTomeAtIndex(index) {
+    if (index <= 0 || index >= currentTomeList.length) return;
+    currentTomeList.splice(index, 1);
+    selectTomePath(undefined, false);
 }
 
 function ClearTomePath() {
@@ -1235,6 +1300,19 @@ function GetAffinityTotalFromList(list, tomeList, subType, subCulture, subSociet
     return result;
 }
 
+// Converts the raw affinity string (from GetAffinityTotalFromList) to the Big-tag HTML
+// format used by the #currentAffinity display element and checkEmpireOfCosmos().
+function affinityToDisplayHtml(affinityStr) {
+    return affinityStr
+        .replace("<empireshadow></empireshadow> ", "<empireshadowBig></empireshadowBig>")
+        .replace("<empirechaos></empirechaos> ", "<empirechaosBig></empirechaosBig>")
+        .replace("<empirenature></empirenature> ", "<empirenatureBig></empirenatureBig>")
+        .replace("<empirearcana></empirearcana> ", "<empirearcanaBig></empirearcanaBig>")
+        .replace("<empirematter></empirematter> ", "<empirematterBig></empirematterBig>")
+        .replace("<empireorder></empireorder> ", "<empireorderBig></empireorderBig>");
+}
+
+
 function RecalculateStats(fromload) {
     var list = GetCurrentChoiceList();
 
@@ -1264,14 +1342,7 @@ function RecalculateStats(fromload) {
     const affinitySummary = document.getElementById("currentAffinity");
 
     currentAffinityTotal = result;
-
-    result = result.replace("<empireshadow></empireshadow> ", "<empireshadowBig></empireshadowBig>");
-    result = result.replace("<empirechaos></empirechaos> ", "<empirechaosBig></empirechaosBig>");
-    result = result.replace("<empirenature></empirenature> ", "<empirenatureBig></empirenatureBig>");
-    result = result.replace("<empirearcana></empirearcana> ", "<empirearcanaBig></empirearcanaBig>");
-    result = result.replace("<empirematter></empirematter> ", "<empirematterBig></empirematterBig>");
-    result = result.replace("<empireorder></empireorder> ", "<empireorderBig></empireorderBig>");
-    affinitySummary.innerHTML = result;
+    affinitySummary.innerHTML = affinityToDisplayHtml(result);
 
     CollectAllPartsForOverview(fromload);
 }
@@ -2663,7 +2734,33 @@ function addUniqueEntry(jsonEntries, jsonEntriesToAdd, newEntry) {
         jsonEntriesToAdd.push(newEntry);
     }
 }
-function GetNextSetOfTomes() {
+
+// Source of truth for tier unlock requirements.
+const tomeRequirements = {
+    2: { minTomes: 2, minAffinity: 0 },
+    3: { minTomes: 4, minAffinity: 3 },
+    4: { minTomes: 6, minAffinity: 6 },
+    5: { minTomes: 8, minAffinity: 8 }
+};
+
+// If pathLength is provided, simulates the path up to that index.
+// Used to show which tomes are valid when inserting a new one in the middle of the list.
+function GetNextSetOfTomes(pathLength) {
+    var savedTomeList, savedAffinityTotal, affinitySummary, savedAffinityHtml;
+    if (pathLength !== undefined) {
+        savedTomeList = currentTomeList;
+        savedAffinityTotal = currentAffinityTotal;
+        affinitySummary = document.getElementById("currentAffinity");
+        savedAffinityHtml = affinitySummary.innerHTML;
+
+        currentTomeList = savedTomeList.slice(0, pathLength);
+        currentAffinityTotal = GetAffinityTotalFromList(
+            GetCurrentChoiceList(), currentTomeList,
+            currentSubType, currentSubCulture, currentSubSociety1, currentSubSociety2
+        );
+        affinitySummary.innerHTML = affinityToDisplayHtml(currentAffinityTotal);
+    }
+
     var listOfNextTomes = [];
 
     for (i = 0; i < jsonTomes.length; i++) {
@@ -2675,7 +2772,7 @@ function GetNextSetOfTomes() {
         }
     }
 
-    if (currentTomeList.length > 1) {
+    if (currentTomeList.length >= tomeRequirements[2].minTomes) {
         // allow tier 2 tomes
         for (i = 0; i < jsonTomes.length; i++) {
             if (jsonTomes[i].tier === 2) {
@@ -2685,12 +2782,12 @@ function GetNextSetOfTomes() {
             }
         }
     }
-    if (currentTomeList.length > 3) {
+    if (currentTomeList.length >= tomeRequirements[3].minTomes) {
         // allow tier 3 tomes
         for (i = 0; i < jsonTomes.length; i++) {
             if (jsonTomes[i].tier === 3) {
                 // 3 affinity
-                if (GetAffinityMatches(currentAffinityTotal, jsonTomes[i].affinities, 2) || checkEmpireOfCosmos(1)) {
+                if (GetAffinityMatches(currentAffinityTotal, jsonTomes[i].affinities, tomeRequirements[3].minAffinity - 1) || checkEmpireOfCosmos(1)) {
                     if (!isInArray(currentTomeList, jsonTomes[i])) {
                         listOfNextTomes.push(jsonTomes[i]);
                     }
@@ -2698,12 +2795,12 @@ function GetNextSetOfTomes() {
             }
         }
     }
-    if (currentTomeList.length > 5) {
+    if (currentTomeList.length >= tomeRequirements[4].minTomes) {
         // allow tier 4 tomes
         for (i = 0; i < jsonTomes.length; i++) {
             if (jsonTomes[i].tier === 4) {
                 // 6 affinity
-                if (GetAffinityMatches(currentAffinityTotal, jsonTomes[i].affinities, 5) || checkEmpireOfCosmos(2)) {
+                if (GetAffinityMatches(currentAffinityTotal, jsonTomes[i].affinities, tomeRequirements[4].minAffinity - 1) || checkEmpireOfCosmos(2)) {
                     if (!isInArray(currentTomeList, jsonTomes[i])) {
                         listOfNextTomes.push(jsonTomes[i]);
                     }
@@ -2711,12 +2808,12 @@ function GetNextSetOfTomes() {
             }
         }
     }
-    if (currentTomeList.length > 7) {
+    if (currentTomeList.length >= tomeRequirements[5].minTomes) {
         // allow tier 5 tomes
         for (i = 0; i < jsonTomes.length; i++) {
             if (jsonTomes[i].tier === 5) {
                 // 8 affinity
-                if (GetAffinityMatches(currentAffinityTotal, jsonTomes[i].affinities, 7) || checkEmpireOfCosmos(3)) {
+                if (GetAffinityMatches(currentAffinityTotal, jsonTomes[i].affinities, tomeRequirements[5].minAffinity - 1) || checkEmpireOfCosmos(3)) {
                     // check if we dont already have a t5, we can only have 1
                     if (!checkIfT5(currentTomeList)) {
                         if (!isInArray(currentTomeList, jsonTomes[i])) {
@@ -2726,6 +2823,12 @@ function GetNextSetOfTomes() {
                 }
             }
         }
+    }
+
+    if (pathLength !== undefined) {
+        currentTomeList = savedTomeList;
+        currentAffinityTotal = savedAffinityTotal;
+        affinitySummary.innerHTML = savedAffinityHtml;
     }
 
     return listOfNextTomes;
@@ -2756,6 +2859,18 @@ function hasAllAffinitiesForEmpireOfCosmos(number) {
         const match = html.match(regex);
         return match && parseInt(match[1], 10) >= number;
     });
+}
+
+// Returns the indices in currentTomeList of tomes whose requirements are no longer satisfied (e.g. after a mid-path removal or a change in ruler or culture).
+// Uses GetNextSetOfTomes() by simulating the path state as it would be just before each tome was added.
+function GetInvalidTomeIndices() {
+    var invalid = new Set();
+    for (var i = 1; i < currentTomeList.length; i++) {
+        if (GetNextSetOfTomes(i).indexOf(currentTomeList[i]) < 0) {
+            invalid.add(i);
+        }
+    }
+    return invalid;
 }
 
 function GetAffinityMatches(affinityTotal, substringToCount, number) {

--- a/HTML/FactionCreator.html
+++ b/HTML/FactionCreator.html
@@ -375,6 +375,70 @@
             .sortingButton:hover {
                 background-color: dimgrey;
             }
+
+            .tome-remove-btn {
+                display: none;
+                position: absolute;
+                top: -18px;
+                right: 2px;
+                color: #ccc;
+                font-size: 13px;
+                font-weight: bold;
+                cursor: pointer;
+                z-index: 10;
+                line-height: 1;
+                background: rgba(0, 0, 0, 0.55);
+                border-radius: 3px;
+                padding: 0 2px;
+            }
+            .tome-button-small::before {
+                content: '';
+                position: absolute;
+                top: -18px;
+                left: 0;
+                right: 0;
+                height: 18px;
+            }
+            .tome-button-small:hover .tome-remove-btn {
+                display: block;
+            }
+            .tome-remove-btn:hover {
+                color: #ff6666;
+            }
+            .tome-warning-icon {
+                position: absolute;
+                top: -18px;
+                left: 2px;
+                font-size: 12px;
+                font-weight: bold;
+                color: #e05252;
+                pointer-events: none;
+                z-index: 10;
+                text-shadow: 0 0 3px #000;
+            }
+            .tome-invalid {
+                outline: 2px solid #e05252;
+                outline-offset: 3px;
+            }
+            .tome-add-slot {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 60px;
+                height: 70px;
+                border: 2px dashed #555;
+                border-radius: 4px;
+                cursor: pointer;
+                color: #555;
+                font-size: 28px;
+                box-sizing: border-box;
+                align-self: center;
+                transition: border-color 0.15s, color 0.15s;
+            }
+            .tome-add-slot:hover {
+                border-color: #d7c297;
+                color: #d7c297;
+            }
         </style>
 
         <script>
@@ -685,12 +749,6 @@
 
                         <button style="float: right; color: red" class="button" onclick="ClearTomePath()">
                             Clear All
-                        </button>
-                        <button
-                            style="float: right; margin-right: 100px; color: red"
-                            class="button"
-                            onclick="RemoveLastTomePath()">
-                            Clear Last
                         </button>
                         <br />
                         <div


### PR DESCRIPTION
Problem: the tome selection UX in the faction creator right now is a bit too rigid. If you carefully place your tomes for your build, then later want to make changes to it, you have to first clear all your tomes up to the ones you want to change, then remember which tomes you had before so you can re-add them. Also changing the starting tome clears everything. This makes experimenting with different combinations of tomes to visualize the whole picture of your build somewhat cumbersome.

This set of changes aim to hopefully make shaping your tome order a little more flexible, by letting you make additions and removals at any point in the path, validating the tomes requirements and showing invalid tomes whenever a change happens that might affect them.

- Tomes can now be inserted at any position in the path by clicking an existing tome — the new tome is added right after the clicked one instead of always appending to the end of the list.
- Added a "+" placeholder slot at the end of the tome path, for discoverability; clicking it appends a new tome to the end, same as clicking the last tome of the list. (image 1)
- When adding a tome in a mid-path position, it only shows tomes that are valid to insert at that point, based on tier and affinity requirements.
- Added a "×" button on each tome (except the starting tome) to remove it. (image 2)
- Removed the "Clear Last Tome" button (redundant now that individual tomes can be removed).
- Invalid tomes (whose requirements are no longer met after removals or other changes that affects them) are now highlighted with a red outline and a "!" icon. (image 3)
- Hovering over an invalid tome shows a tooltip explaining the reason. (image 3)
- Changing the starting tome in the Ruler section no longer clears the entire tome path — remaining tomes stay and are re-evaluated for validity.
- Changing the ruler type, culture, or subculture now also re-evaluates the tome path for validity (since affinities might have changed).

Image 1

<img width="277" height="172" alt="image" src="https://github.com/user-attachments/assets/6b396798-1270-4aa6-88ab-d55416aed2b2" />

Image 2

<img width="123" height="169" alt="image" src="https://github.com/user-attachments/assets/5b5cc3e6-1613-4d4e-a277-ca3bae007167" />

Image 3

<img width="1122" height="583" alt="image" src="https://github.com/user-attachments/assets/68f18bd0-6d03-4f03-9559-307fa80145f4" />